### PR TITLE
Only run cape checks on item model

### DIFF
--- a/thonkutil-capes-v1/src/main/java/com/jab125/thonkutil/mixin/ModelLoaderMixin.java
+++ b/thonkutil-capes-v1/src/main/java/com/jab125/thonkutil/mixin/ModelLoaderMixin.java
@@ -32,7 +32,7 @@ public class ModelLoaderMixin {
     @Inject(method = "loadModelFromJson", at = @At(value = "HEAD"), cancellable = true)
     public void loadModelFromJson(Identifier id, CallbackInfoReturnable<JsonUnbakedModel> cir) {
         // System.out.println(id.getNamespace() + ":" + id.getPath().split("/")[1]);
-        if (!(Registry.ITEM.get(Identifier.tryParse(id.getNamespace() + ":" + id.getPath().split("/")[1])) instanceof CapeItem))
+        if (!id.getPath().startsWith("item/") || !(Registry.ITEM.get(Identifier.tryParse(id.getNamespace() + ":" + id.getPath().split("/")[1])) instanceof CapeItem))
             return;
         String b = id.getNamespace() + ":" + "cape/" + id.getPath().split("/")[1];
         //Here, we can do different checks to see if the current item is a block-item, a tool, or other.


### PR DESCRIPTION
It'd be nice if you backported the fix to 1.18