### PR TITLE
Removed unrelated code.

### DIFF
--- a/thonkutil-axolotl-api-v1/src/main/java/com/jab125/limeappleboat/thonkutil/axolotl/v1/impl/ThonkUtilAxolotlApi.java
+++ b/thonkutil-axolotl-api-v1/src/main/java/com/jab125/limeappleboat/thonkutil/axolotl/v1/impl/ThonkUtilAxolotlApi.java
@@ -16,28 +16,9 @@
 package com.jab125.limeappleboat.thonkutil.axolotl.v1.impl;
 
 import net.fabricmc.api.ModInitializer;
-import net.minecraft.block.AbstractBlock;
-import net.minecraft.block.Block;
-import net.minecraft.block.Material;
-import net.minecraft.util.registry.Registry;
-
-import java.util.ArrayList;
-import java.util.HashMap;
 
 public class ThonkUtilAxolotlApi implements ModInitializer {
-    private static HashMap<String, Block> registry = new HashMap<>();
     @Override
     public void onInitialize() {
-        var s = new String[]{"a", "b", "c"};
-        for (String s1 : s) {
-            register(s1, Registry.register(Registry.BLOCK, s1, new Block(AbstractBlock.Settings.of(Material.METAL))));
-        }
-    }
-
-    private void register(String d, Block block) {
-        registry.put(d, block);
-    }
-    public static Block getBlock(String s) {
-        return registry.get(s);
     }
 }


### PR DESCRIPTION
Apart that isn't related to the axolotl. It also crashes on 1.19.3 snapshots due of field_11146 not existing (DefaultedRegistry class field).